### PR TITLE
fix: broken links to videos and articles

### DIFF
--- a/MODULE_2.md
+++ b/MODULE_2.md
@@ -80,7 +80,7 @@ Explore these resources to further your understanding:
 ## Merkle Trees
 
 A Merkle tree is a core component of blockchain and cryptography. It's a binary tree filled with cryptographic hashes. This structure enables efficient and secure verification of the contents of large data structures. To understand more about Merkle trees, read the following:
-- [How Merkle Trees Enable the Decentralized Web! [9:43]](https://www.youtube.com/watch?v=YIc6MNfv5iQ)
+- [How Merkle Trees Enable the Decentralized Web! [10:05]](https://www.youtube.com/watch?v=3giNelTfeAk)
 - [Merkle Trees and Merkle Roots Explained](https://academy.binance.com/en/articles/merkle-trees-and-merkle-roots-explained)
 - [Visualizing Efficient Merkle Trees for Zero-Knowledge Proofs](https://kndrck.co/posts/efficient-merkletrees-zk-proofs/)
 - [The Ultimate Merkle Tree Guide in Solidity](https://soliditydeveloper.com/merkle-tree)

--- a/MODULE_3.md
+++ b/MODULE_3.md
@@ -60,7 +60,7 @@ For more on EdDSA, check out the following links:
 
 Many of the following topics will depend upon what is called pairing-based cryptography. These two articles set the stage and foundation:
 
-- **[Exploring Elliptic Curve Pairings by Vitalik Buterin](https://vitalik.ca/general/2017/01/14/exploring_ecp.html)** - This resource builds upon the knowledge you learned above regarding elliptic curves and sets the stage for the topics discussed below. It is an excellent introduction to the topic.
+- **[Exploring Elliptic Curve Pairings by Vitalik Buterin](https://medium.com/@VitalikButerin/exploring-elliptic-curve-pairings-c73c1864e627)** - This resource builds upon the knowledge you learned above regarding elliptic curves and sets the stage for the topics discussed below. It is an excellent introduction to the topic.
 - **[Pairings or Bilinear Maps by Alin Tomescu](https://alinush.github.io/2022/12/31/pairings-or-bilinear-maps.html)** - This resource begins with an introduction to the three fundamental properties of bilinear maps. Building on this foundation, it further explores applications such as the Tripartite Diffie-Hellman protocol, BLS signatures, and Identity-Based Encryption (IBE).
 
 Make sure you read these two articles in full before proceeding.
@@ -91,7 +91,7 @@ The following articles offer a great introduction to BLS signatures and why they
 
 Polynomial Commitments are cryptographic tools that allow the hiding of some coefficients while revealing others. They're used in various cryptographic proofs and blockchain protocols. For a better understanding of Polynomial Commitments, consider these resources:
 
-- [Polynomials](https://vitalik.ca/general/2021/01/26/snarks.html#polynomials) section of Vitalik's article on zk-SNARKs.
+- [Polynomials](https://vitalik.eth.limo/general/2021/01/26/snarks.html#polynomials) section of Vitalik's article on zk-SNARKs.
 - [KZG in Practice: Polynomial Commitment Schemes and Their Usage in Scaling Ethereum](https://scroll.io/blog/kzg)
 
 KZG Polynomial Commitments is another technology that relies on pairing-based cryptography. The protocol is built upon pairing-friendly elliptic curves and bilinear properties. With this protocol, both the proof and commitment size is constant, no matter the degree of the polynomial being used.
@@ -106,7 +106,7 @@ Scroll's zk-rollup implementation makes use of this commitment scheme to commit 
 
 The concept of a trusted setup is an important part of the KZG Polynomial commitment scheme, and indeed part of the wider culture of Ethereum. Here are a few resources to learn more about trusted setups.
 
-- [How do trusted setups work? by Vitalik Buterin](https://vitalik.ca/general/2022/03/14/trustedsetup.html)
+- [How do trusted setups work? by Vitalik Buterin](https://vitalik.eth.limo/general/2022/03/14/trustedsetup.html)
 - [On-Chain Trusted Setup Ceremony by a16zcrypto](https://a16zcrypto.com/posts/article/on-chain-trusted-setup-ceremony/)
 - [The KZG Ceremony - or How I Learnt to Stop Worrying and Love Trusted Setups by Carl Beekhuizen [27:27]](https://www.youtube.com/watch?v=dTBy661ubgg)
 - [Trusted Setup by 0xParc [48:42]](https://learn.0xparc.org/materials/circom/learning-group-1/trusted-setup/)

--- a/MODULE_4.md
+++ b/MODULE_4.md
@@ -87,7 +87,7 @@ PLONK has fast become one of the favourite proof systems because of its "univers
 
 Here are a couple resources to understand how PLONK works:
 
-- [Understanding PLONK by Vitalik Buterin](https://vitalik.ca/general/2019/09/22/plonk.html)
+- [Understanding PLONK by Vitalik Buterin](https://vitalik.eth.limo/general/2019/09/22/plonk.html)
 - [How does PLONK work? by David Wong](https://cryptologie.net/article/529/how-does-plonk-work-part-1-whats-plonk/)
 - [How PLONK Works: Part 1 by CoinGeek](https://coingeek.com/how-plonk-works-part-1/)
 - [How PLONK Works: Part 2 by CoinGeek](https://coingeek.com/how-plonk-works-part-2/)


### PR DESCRIPTION
### Description

- Updated links to Vitalik's old blog page with the new links.
- Corrected broken YouTube video link.

### Affected Tutorials

- Module Name: Module 2, Module 3, Module 4

### Type of Change

- [ ] Typo/grammar fix
- [ ] Code correction (e.g., a bug in a code snippet)
- [ ] New tutorial or section
- [x] Other (Broken links fix):

### Checklist

- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to related documentation.
