### PR TITLE
Fix grammatical issues in documentation

### DIFF
--- a/2024/week0_course_primer.md
+++ b/2024/week0_course_primer.md
@@ -83,7 +83,7 @@ Before we delve into the core content of the module, consider acquainting yourse
 - [Zero Knowledge Proofs: An illustrated primer [Part 1]](https://blog.cryptographyengineering.com/2014/11/27/zero-knowledge-proofs-illustrated-primer/)
 - [Zero Knowledge Proofs: An illustrated primer [Part 2]](https://blog.cryptographyengineering.com/2017/01/21/zero-knowledge-proofs-an-illustrated-primer-part-2/)
 
-Then lets to see a graphic explanation about the Zero-Knowledge proofs generic workflow:
+Then let's look at a graphic explanation about the Zero-Knowledge proofs generic workflow:
 
 ```mermaid
 sequenceDiagram

--- a/2024/week2_more_crypto_snarks_starks.md
+++ b/2024/week2_more_crypto_snarks_starks.md
@@ -28,9 +28,9 @@ Read this article for a more in-depth mathematical look into how it works (optio
 If you prefer to read some code, check out this article:
 - [Explaining KZG Commitment with Code Walkthrough by Kai Jun Eer](https://kaijuneer.medium.com/explaining-kzg-commitment-with-code-walkthrough-216638a620c9)
 
-### Trusted Setups
+### Trusted Setup
 
-Trusted setups is a process to generate a bunch of different points on elliptic curve. You can use these points with polynomial commitment schemes. Each point has same generator but different power. You can use these points to represent the variable terms in the polynomial. Therefore, the result of the polynomial commitment scheme with trusted setup is also a point on the elliptic curve. [Read this article by inevitable Ethereum to understand the concept better](https://www.inevitableeth.com/en/home/concepts/pcs-trusted-setup)
+Trusted setup is a process to generate a bunch of different points on elliptic curve. You can use these points with polynomial commitment schemes. Each point has same generator but different power. You can use these points to represent the variable terms in the polynomial. Therefore, the result of the polynomial commitment scheme with trusted setup is also a point on the elliptic curve. [Read this article by inevitable Ethereum to understand the concept better](https://www.inevitableeth.com/en/home/concepts/pcs-trusted-setup)
 
 ### STARKs and SNARKs
 


### PR DESCRIPTION


Changes in 2024/week2_more_crypto_snarks_starks.md:

1. "Trusted Setups" -> "Trusted Setup" (heading)
2. "Trusted setups is" -> "Trusted setup is" 
3. "lets to see" -> "let's look at"

Reasons:
- Maintain singular form consistency
- Fix subject-verb agreement
- Improve readability and proper English phrasing

These changes improve document accuracy while preserving technical content.
