### PR TITLE
docs: fix verb tense in setup step description

### DIFF
--- a/2024/week1_cryptographic_basics.md
+++ b/2024/week1_cryptographic_basics.md
@@ -19,7 +19,7 @@ sequenceDiagram
 
     Developer->>Circom: Writes circuit definition
     Developer->>Circom: Compiles circuit
-    Developer->>Circom: Run Trusted Setup
+    Developer->>Circom: Runs Trusted Setup
     Circom->>Developer: Return the ZK artifacts
     Developer->>ProverModule: Installs Witness calculator & Proving key
     Developer->>Verifier: Deploys contract or service with .vkey.json 


### PR DESCRIPTION
### Description

Noticed a small inconsistency in the list of steps - changed "Run Trusted Setup" to "Runs Trusted Setup" to match the tense used in the other items ("Writes", "Compiles").

### Type of Change

- [x] Typo/grammar fix
- [ ] Code correction (e.g., a bug in a code snippet)
- [ ] New tutorial or section
- [ ] Other (please describe):

### Checklist

- [x] I have performed a self-review of my own changes.
- [ ] I have made corresponding changes to related documentation.
